### PR TITLE
Add docker info to readme and a sample docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,21 @@ in your Heroku dashboard and push the code.
 
 Typical reasons for running your own instance include:
 
-* availability/reliability requirements
+- availability/reliability requirements
   (the [reference instance][calapi] is self-hosted by the author
   and only maintained as free time permits;
   it may be terminated at any time)
-* very high traffic expected
-* custom calendar data that cannot be released as open-source
+- very high traffic expected
+- custom calendar data that cannot be released as open-source
   (e.g. because it is copyrighted by the diocese)
-* required control over data and algorithm updates
+- required control over data and algorithm updates
   (the reference instance is updated without prior notice)
+
+## Running with Docker
+
+This repository includes a `dockerfile` and a `docker-compose.yml`. You can run your own instance by running the following command from inside this folder:
+
+`$ docker-compose up -d --build`
 
 ## Running specs
 
@@ -52,7 +58,7 @@ In order to add a new calendar:
 
 ## Client libraries
 
-* Ruby: [calendarium-romanum-remote][caro_remote]
+- Ruby: [calendarium-romanum-remote][caro_remote]
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2.3"
+
+services:
+  server:
+    build: .
+    ports:
+      - 9292:9292


### PR DESCRIPTION
Continuation of #14, as requested.

It would probably be best for you to make an account on Dockerhub and connect this repository to it. Dockerhub will automatically build, tag, and release prebuilt images based off the dockerfile on the repo.

Then people can spin up an image by running `docker run -p 9292:9292 igneus/church-calendar-api:latest`.